### PR TITLE
Fix output format of image

### DIFF
--- a/normalisecolor/Dockerfile
+++ b/normalisecolor/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog 
     && chmod +x /usr/bin/fwatchdog
 
 # Populate example here - i.e. "cat", "sha512sum" or "node index.js"
-ENV fprocess="convert - -separate -normalize -combine fd:1"
+ENV fprocess="convert - -flatten +matte -separate -normalize -combine fd:1"
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD ["fwatchdog"]


### PR DESCRIPTION
This commit fixes the output format of the image for `normalisecolor`. It was returning RGBA (instead of RGB) which was breaking things.

Signed-off-by: Finnian Anderson <get@finnian.io>